### PR TITLE
Update IntVarImpl.java - Changement de la fonction car accès en O(n^2)

### DIFF
--- a/src/main/java/minicp/engine/core/IntVarImpl.java
+++ b/src/main/java/minicp/engine/core/IntVarImpl.java
@@ -156,8 +156,8 @@ public class IntVarImpl implements IntVar {
 
 
     protected void scheduleAll(StateStack<Constraint> constraints) {
-        for (int i = 0; i < constraints.size(); i++)
-            cp.schedule(constraints.get(i));
+        for (Constraint c : constraints)
+            cp.schedule(c);
     }
 
     @Override


### PR DESCRIPTION
La fonction get semblant être en O(n) à l’intérieur de la boucle qui est également en O(n) semblerait donné du O(n^2). 

Je suppose qu’en utilisant l’itérateur de la Stack permettrait de passer ce bout de code en O(n) ?